### PR TITLE
Add minute precision support to daily schedule generation

### DIFF
--- a/src/google_ads_alert/schedule.py
+++ b/src/google_ads_alert/schedule.py
@@ -22,10 +22,15 @@ class DailyScheduleConfig:
         the project default (Asia/Tokyo).
     start_hour:
         First hour (0-23) when the schedule may trigger. The exact first run
-        will be aligned to this hour.
+        will be aligned to this hour and ``start_minute``.
+    start_minute:
+        Minute component (0-59) used for the first run of the day.
     end_hour:
         Last hour (0-23) allowed for execution. When multiple runs are
-        generated the final one will be aligned to ``end_hour``.
+        generated the final one will be aligned to ``end_hour`` and
+        ``end_minute``.
+    end_minute:
+        Minute component (0-59) of the final run of the day.
     run_count:
         Desired number of executions per day. Defaults to three so alerts land
         at 8:00, 14:00, and 20:00 in the Asia/Tokyo timezone.
@@ -33,7 +38,9 @@ class DailyScheduleConfig:
 
     timezone: ZoneInfo | None = None
     start_hour: int = 8
+    start_minute: int = 0
     end_hour: int = 20
+    end_minute: int = 0
     run_count: int = 3
 
 
@@ -42,13 +49,22 @@ def _validate_hour(hour: int) -> None:
         raise ValueError("Hour must be within the range 0-23")
 
 
-def _build_anchor_datetime(target_date: date, hour: int, tz: ZoneInfo) -> datetime:
+def _validate_minute(minute: int) -> None:
+    if not 0 <= minute <= 59:
+        raise ValueError("Minute must be within the range 0-59")
+
+
+def _build_anchor_datetime(
+    target_date: date, hour: int, minute: int, tz: ZoneInfo
+) -> datetime:
     _validate_hour(hour)
+    _validate_minute(minute)
     return datetime(
         year=target_date.year,
         month=target_date.month,
         day=target_date.day,
         hour=hour,
+        minute=minute,
         tzinfo=tz,
     )
 
@@ -58,19 +74,23 @@ def generate_daily_schedule(
 ) -> List[datetime]:
     """Return alert run times for ``target_date``.
 
-    The generated schedule always includes the start and end hours. When
+    The generated schedule always includes the start and end anchors. When
     ``run_count`` is one the result consists of the start hour only. For
     higher counts the remaining entries are evenly spaced between the
-    anchors.
+    anchors (hour and minute precision).
     """
 
     cfg = config or DailyScheduleConfig()
     tz = _coerce_timezone(cfg.timezone)
-    start_dt = _build_anchor_datetime(target_date, cfg.start_hour, tz)
+    start_dt = _build_anchor_datetime(
+        target_date, cfg.start_hour, cfg.start_minute, tz
+    )
     if cfg.run_count <= 1:
         return [start_dt]
 
-    end_dt = _build_anchor_datetime(target_date, cfg.end_hour, tz)
+    end_dt = _build_anchor_datetime(
+        target_date, cfg.end_hour, cfg.end_minute, tz
+    )
     if end_dt < start_dt:
         raise ValueError("end_hour must be greater than or equal to start_hour")
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -43,6 +43,30 @@ def test_generate_schedule_with_single_run_returns_start_only():
     assert schedule[0].hour == 10
 
 
+def test_generate_schedule_supports_minute_precision():
+    schedule = generate_daily_schedule(
+        date(2024, 1, 5),
+        DailyScheduleConfig(
+            start_hour=9,
+            start_minute=30,
+            end_hour=18,
+            end_minute=15,
+            run_count=4,
+        ),
+    )
+
+    assert schedule[0].hour == 9
+    assert schedule[0].minute == 30
+    assert schedule[-1].hour == 18
+    assert schedule[-1].minute == 15
+    assert schedule[1] < schedule[2]  # intermediate ordering preserved
+    total_seconds = (schedule[-1] - schedule[0]).total_seconds()
+    expected_step = total_seconds / 3
+    for i in range(len(schedule) - 1):
+        delta = (schedule[i + 1] - schedule[i]).total_seconds()
+        assert pytest.approx(delta, rel=1e-9) == expected_step
+
+
 def test_generate_schedule_invalid_hours_raise_error():
     with pytest.raises(ValueError):
         generate_daily_schedule(date(2024, 1, 5), DailyScheduleConfig(start_hour=-1))
@@ -53,4 +77,16 @@ def test_generate_schedule_invalid_hours_raise_error():
     with pytest.raises(ValueError):
         generate_daily_schedule(
             date(2024, 1, 5), DailyScheduleConfig(start_hour=20, end_hour=10, run_count=3)
+        )
+
+
+def test_generate_schedule_invalid_minutes_raise_error():
+    with pytest.raises(ValueError):
+        generate_daily_schedule(
+            date(2024, 1, 5), DailyScheduleConfig(start_minute=-1)
+        )
+
+    with pytest.raises(ValueError):
+        generate_daily_schedule(
+            date(2024, 1, 5), DailyScheduleConfig(end_minute=60)
         )


### PR DESCRIPTION
## Summary
- allow configuring start and end minute components for daily schedules and validate their ranges
- update schedule generation to use minute-level anchors when building the run times
- cover the new behaviour with tests for minute precision and validation failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db9ea98fec832e9548d825ae0c5821