### PR TITLE
Add schedule helper to locate next run time

### DIFF
--- a/src/google_ads_alert/__init__.py
+++ b/src/google_ads_alert/__init__.py
@@ -11,7 +11,11 @@ from .forecast import (
     calculate_monthly_pace,
     build_combined_forecast,
 )
-from .schedule import DailyScheduleConfig, generate_daily_schedule
+from .schedule import (
+    DailyScheduleConfig,
+    find_next_run_datetime,
+    generate_daily_schedule,
+)
 from .notification import SlackNotificationOptions, build_slack_notification_payload
 
 __all__ = [
@@ -25,6 +29,7 @@ __all__ = [
     "calculate_monthly_pace",
     "build_combined_forecast",
     "DailyScheduleConfig",
+    "find_next_run_datetime",
     "generate_daily_schedule",
     "SlackNotificationOptions",
     "build_slack_notification_payload",


### PR DESCRIPTION
## Summary
- add a `find_next_run_datetime` helper that normalizes schedule entries and returns the next executable run
- expose the helper through the package initializer for downstream consumers
- extend schedule tests to cover timezone conversion and all-past scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dba2c36b20832e856580e163424f71