### PR TITLE
Run回数が不正な場合にスケジュール生成を失敗させる

### DIFF
--- a/src/google_ads_alert/schedule.py
+++ b/src/google_ads_alert/schedule.py
@@ -77,15 +77,19 @@ def generate_daily_schedule(
     The generated schedule always includes the start and end anchors. When
     ``run_count`` is one the result consists of the start hour only. For
     higher counts the remaining entries are evenly spaced between the
-    anchors (hour and minute precision).
+    anchors (hour and minute precision). ``run_count`` must be a positive
+    integer, otherwise a :class:`ValueError` is raised.
     """
 
     cfg = config or DailyScheduleConfig()
+    if cfg.run_count <= 0:
+        raise ValueError("run_count must be a positive integer")
+
     tz = _coerce_timezone(cfg.timezone)
     start_dt = _build_anchor_datetime(
         target_date, cfg.start_hour, cfg.start_minute, tz
     )
-    if cfg.run_count <= 1:
+    if cfg.run_count == 1:
         return [start_dt]
 
     end_dt = _build_anchor_datetime(

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -90,3 +90,11 @@ def test_generate_schedule_invalid_minutes_raise_error():
         generate_daily_schedule(
             date(2024, 1, 5), DailyScheduleConfig(end_minute=60)
         )
+
+
+def test_generate_schedule_non_positive_run_count_is_rejected():
+    for invalid in (0, -2):
+        with pytest.raises(ValueError):
+            generate_daily_schedule(
+                date(2024, 1, 5), DailyScheduleConfig(run_count=invalid)
+            )


### PR DESCRIPTION
## Summary
- run_count が0以下の設定を受け取った際に ValueError を送出するようバリデーションを追加
- generate_daily_schedule のドキュメンテーションを更新して挙動を明記
- 非正 run_count を拒否する単体テストを追加

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dba2c66604832e868f8fb11ca31615