### PR TITLE
Add environment configuration loader and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# Google Ads API 認証情報
+GOOGLE_ADS_DEVELOPER_TOKEN=
+GOOGLE_ADS_CLIENT_ID=
+GOOGLE_ADS_CLIENT_SECRET=
+GOOGLE_ADS_REFRESH_TOKEN=
+GOOGLE_ADS_CUSTOMER_ID=
+# 任意: 管理アカウントを利用する場合に設定
+# GOOGLE_ADS_LOGIN_CUSTOMER_ID=
+# 任意: 既定は Asia/Tokyo
+# GOOGLE_ADS_TIMEZONE=
+# 任意: エンドポイントを切り替える際に利用
+# GOOGLE_ADS_ENDPOINT=
+
+# Slack 通知設定
+SLACK_WEBHOOK_URL=
+# 任意: メッセージ見出しに利用
+# SLACK_ACCOUNT_NAME=
+# 任意: 通貨記号（例: ¥, $, €）
+# SLACK_CURRENCY_SYMBOL=
+# 任意: タイムゾーン。省略時は Asia/Tokyo
+# SLACK_TIMEZONE=
+# 任意: 月次セクション表示の有無 (true/false)
+# SLACK_INCLUDE_MONTHLY_SECTION=
+# 任意: 時間あたり消化の表示有無 (true/false)
+# SLACK_INCLUDE_SPEND_RATE=
+
+# アラートスケジュール設定
+# 任意: 実行タイムゾーン。省略時は Asia/Tokyo
+# ALERT_TIMEZONE=
+# 任意: 初回実行時刻 (0-23)
+# ALERT_START_HOUR=8
+# 任意: 初回実行の分 (0-59)
+# ALERT_START_MINUTE=0
+# 任意: 最終実行時刻 (0-23)
+# ALERT_END_HOUR=20
+# 任意: 最終実行の分 (0-59)
+# ALERT_END_MINUTE=0
+# 任意: 1日あたりの実行回数
+# ALERT_RUN_COUNT=3
+
+# 任意: 通知に使用する予算情報
+# DAILY_BUDGET=
+# MONTHLY_BUDGET=

--- a/src/google_ads_alert/__init__.py
+++ b/src/google_ads_alert/__init__.py
@@ -1,5 +1,14 @@
 """Core package for Google Ads budget alert system."""
 
+from .config import (
+    ApplicationConfig,
+    ConfigError,
+    SlackConfig,
+    load_config,
+    load_google_ads_config,
+    load_schedule_config,
+    load_slack_config,
+)
 from .forecast import (
     DailyForecastInput,
     DailyForecastResult,
@@ -29,6 +38,13 @@ from .schedule import (
 from .notification import SlackNotificationOptions, build_slack_notification_payload
 
 __all__ = [
+    "ApplicationConfig",
+    "ConfigError",
+    "SlackConfig",
+    "load_config",
+    "load_google_ads_config",
+    "load_schedule_config",
+    "load_slack_config",
     "DailyForecastInput",
     "DailyForecastResult",
     "CombinedForecastInput",

--- a/src/google_ads_alert/config.py
+++ b/src/google_ads_alert/config.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Environment driven configuration loading helpers."""
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import os
+
+from zoneinfo import ZoneInfo
+
+from .forecast import _coerce_timezone
+from .google_ads_client import GoogleAdsClientConfig, GoogleAdsCredentials
+from .notification import SlackNotificationOptions
+from .schedule import DailyScheduleConfig
+
+
+class ConfigError(ValueError):
+    """Raised when configuration values are missing or invalid."""
+
+
+@dataclass(frozen=True)
+class SlackConfig:
+    """Slack specific configuration including the webhook and payload options."""
+
+    webhook_url: str
+    options: SlackNotificationOptions
+
+
+@dataclass(frozen=True)
+class ApplicationConfig:
+    """Aggregate configuration required to run the alert workflow."""
+
+    google_ads: GoogleAdsClientConfig
+    slack: SlackConfig
+    schedule: DailyScheduleConfig
+    daily_budget: float | None = None
+    monthly_budget: float | None = None
+
+
+def _read_env(env: Mapping[str, str] | None = None) -> Mapping[str, str]:
+    if env is None:
+        return os.environ
+    return env
+
+
+def _get_required(env: Mapping[str, str], key: str) -> str:
+    value = env.get(key, "").strip()
+    if not value:
+        raise ConfigError(f"Missing required environment variable: {key}")
+    return value
+
+
+def _get_optional(env: Mapping[str, str], key: str) -> str | None:
+    value = env.get(key)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _parse_timezone(value: str | None) -> ZoneInfo | None:
+    if not value:
+        return None
+    try:
+        return ZoneInfo(value)
+    except Exception as exc:  # pragma: no cover - ZoneInfo raises various errors
+        raise ConfigError(f"Invalid timezone identifier: {value}") from exc
+
+
+def _parse_int(value: str | None, *, default: int) -> int:
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ConfigError(f"Expected integer for value '{value}'") from exc
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None or value.strip() == "":
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ConfigError(f"Expected float for value '{value}'") from exc
+
+
+def _parse_bool(value: str | None, *, default: bool) -> bool:
+    if value is None or value.strip() == "":
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "yes", "y", "on"}:
+        return True
+    if normalized in {"false", "0", "no", "n", "off"}:
+        return False
+    raise ConfigError(f"Expected boolean value for '{value}'")
+
+
+def load_google_ads_config(env: Mapping[str, str] | None = None) -> GoogleAdsClientConfig:
+    """Build :class:`GoogleAdsClientConfig` from environment variables."""
+
+    values = _read_env(env)
+    credentials = GoogleAdsCredentials(
+        developer_token=_get_required(values, "GOOGLE_ADS_DEVELOPER_TOKEN"),
+        client_id=_get_required(values, "GOOGLE_ADS_CLIENT_ID"),
+        client_secret=_get_required(values, "GOOGLE_ADS_CLIENT_SECRET"),
+        refresh_token=_get_required(values, "GOOGLE_ADS_REFRESH_TOKEN"),
+        login_customer_id=_get_optional(values, "GOOGLE_ADS_LOGIN_CUSTOMER_ID"),
+    )
+
+    timezone = _parse_timezone(_get_optional(values, "GOOGLE_ADS_TIMEZONE"))
+    endpoint = _get_optional(values, "GOOGLE_ADS_ENDPOINT")
+
+    return GoogleAdsClientConfig(
+        customer_id=_get_required(values, "GOOGLE_ADS_CUSTOMER_ID"),
+        credentials=credentials,
+        timezone=timezone,
+        endpoint=endpoint or GoogleAdsClientConfig.__dataclass_fields__["endpoint"].default,
+    )
+
+
+def load_slack_config(env: Mapping[str, str] | None = None) -> SlackConfig:
+    """Build :class:`SlackConfig` using environment variables."""
+
+    values = _read_env(env)
+    webhook_url = _get_required(values, "SLACK_WEBHOOK_URL")
+    timezone = _parse_timezone(_get_optional(values, "SLACK_TIMEZONE"))
+    options = SlackNotificationOptions(
+        account_name=_get_optional(values, "SLACK_ACCOUNT_NAME"),
+        currency_symbol=(
+            _get_optional(values, "SLACK_CURRENCY_SYMBOL")
+            or SlackNotificationOptions.__dataclass_fields__["currency_symbol"].default
+        ),
+        timezone=_coerce_timezone(timezone),
+        include_monthly_section=_parse_bool(
+            values.get("SLACK_INCLUDE_MONTHLY_SECTION"),
+            default=SlackNotificationOptions.__dataclass_fields__["include_monthly_section"].default,
+        ),
+        include_spend_rate=_parse_bool(
+            values.get("SLACK_INCLUDE_SPEND_RATE"),
+            default=SlackNotificationOptions.__dataclass_fields__["include_spend_rate"].default,
+        ),
+    )
+
+    return SlackConfig(webhook_url=webhook_url, options=options)
+
+
+def load_schedule_config(env: Mapping[str, str] | None = None) -> DailyScheduleConfig:
+    """Build :class:`DailyScheduleConfig` from environment variables."""
+
+    values = _read_env(env)
+    defaults = DailyScheduleConfig()
+    timezone = _parse_timezone(_get_optional(values, "ALERT_TIMEZONE"))
+    return DailyScheduleConfig(
+        timezone=_coerce_timezone(timezone),
+        start_hour=_parse_int(values.get("ALERT_START_HOUR"), default=defaults.start_hour),
+        start_minute=_parse_int(values.get("ALERT_START_MINUTE"), default=defaults.start_minute),
+        end_hour=_parse_int(values.get("ALERT_END_HOUR"), default=defaults.end_hour),
+        end_minute=_parse_int(values.get("ALERT_END_MINUTE"), default=defaults.end_minute),
+        run_count=_parse_int(values.get("ALERT_RUN_COUNT"), default=defaults.run_count),
+    )
+
+
+def load_config(env: Mapping[str, str] | None = None) -> ApplicationConfig:
+    """Load the aggregated application configuration from ``env``."""
+
+    values = _read_env(env)
+    google_ads = load_google_ads_config(values)
+    slack = load_slack_config(values)
+    schedule = load_schedule_config(values)
+    daily_budget = _parse_float(_get_optional(values, "DAILY_BUDGET"))
+    monthly_budget = _parse_float(_get_optional(values, "MONTHLY_BUDGET"))
+
+    return ApplicationConfig(
+        google_ads=google_ads,
+        slack=slack,
+        schedule=schedule,
+        daily_budget=daily_budget,
+        monthly_budget=monthly_budget,
+    )
+
+
+__all__ = [
+    "ApplicationConfig",
+    "ConfigError",
+    "SlackConfig",
+    "load_config",
+    "load_google_ads_config",
+    "load_schedule_config",
+    "load_slack_config",
+]
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from google_ads_alert.config import (
+    ApplicationConfig,
+    ConfigError,
+    SlackConfig,
+    load_config,
+    load_google_ads_config,
+    load_schedule_config,
+    load_slack_config,
+)
+from google_ads_alert.google_ads_client import GoogleAdsClientConfig
+from google_ads_alert.schedule import DailyScheduleConfig
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "GOOGLE_ADS_DEVELOPER_TOKEN": "dev-token",
+        "GOOGLE_ADS_CLIENT_ID": "client-id",
+        "GOOGLE_ADS_CLIENT_SECRET": "client-secret",
+        "GOOGLE_ADS_REFRESH_TOKEN": "refresh-token",
+        "GOOGLE_ADS_CUSTOMER_ID": "123-456-7890",
+        "SLACK_WEBHOOK_URL": "https://hooks.slack.test/T000/B000/XXX",
+    }
+
+
+def test_load_google_ads_config_success() -> None:
+    env = _base_env() | {
+        "GOOGLE_ADS_TIMEZONE": "UTC",
+        "GOOGLE_ADS_LOGIN_CUSTOMER_ID": "987-654-3210",
+        "GOOGLE_ADS_ENDPOINT": "https://example.googleapis.com",
+    }
+
+    config = load_google_ads_config(env)
+
+    assert isinstance(config, GoogleAdsClientConfig)
+    assert config.customer_id == "123-456-7890"
+    assert config.credentials.developer_token == "dev-token"
+    assert config.credentials.login_customer_id == "987-654-3210"
+    assert config.timezone == ZoneInfo("UTC")
+    assert config.endpoint == "https://example.googleapis.com"
+
+
+def test_load_google_ads_config_missing_required() -> None:
+    env = _base_env()
+    del env["GOOGLE_ADS_CUSTOMER_ID"]
+
+    with pytest.raises(ConfigError):
+        load_google_ads_config(env)
+
+
+def test_load_slack_config_defaults_and_overrides() -> None:
+    env = _base_env() | {
+        "SLACK_ACCOUNT_NAME": "Marketing Team",
+        "SLACK_CURRENCY_SYMBOL": "$",
+        "SLACK_TIMEZONE": "UTC",
+        "SLACK_INCLUDE_MONTHLY_SECTION": "false",
+        "SLACK_INCLUDE_SPEND_RATE": "yes",
+    }
+
+    config = load_slack_config(env)
+
+    assert isinstance(config, SlackConfig)
+    assert config.webhook_url.endswith("XXX")
+    assert config.options.account_name == "Marketing Team"
+    assert config.options.currency_symbol == "$"
+    assert config.options.timezone == ZoneInfo("UTC")
+    assert config.options.include_monthly_section is False
+    assert config.options.include_spend_rate is True
+
+
+def test_load_schedule_config_with_overrides() -> None:
+    env = _base_env() | {
+        "ALERT_TIMEZONE": "UTC",
+        "ALERT_START_HOUR": "9",
+        "ALERT_START_MINUTE": "30",
+        "ALERT_END_HOUR": "21",
+        "ALERT_END_MINUTE": "45",
+        "ALERT_RUN_COUNT": "4",
+    }
+
+    config = load_schedule_config(env)
+
+    assert isinstance(config, DailyScheduleConfig)
+    assert config.timezone == ZoneInfo("UTC")
+    assert config.start_hour == 9
+    assert config.start_minute == 30
+    assert config.end_hour == 21
+    assert config.end_minute == 45
+    assert config.run_count == 4
+
+
+def test_load_config_aggregates_sections() -> None:
+    env = _base_env() | {
+        "GOOGLE_ADS_TIMEZONE": "UTC",
+        "ALERT_TIMEZONE": "UTC",
+        "ALERT_RUN_COUNT": "1",
+        "SLACK_INCLUDE_SPEND_RATE": "true",
+        "DAILY_BUDGET": "50000.5",
+        "MONTHLY_BUDGET": "1000000",
+    }
+
+    config = load_config(env)
+
+    assert isinstance(config, ApplicationConfig)
+    assert config.google_ads.timezone == ZoneInfo("UTC")
+    assert config.slack.options.include_spend_rate is True
+    assert config.schedule.run_count == 1
+    assert config.daily_budget == pytest.approx(50000.5)
+    assert config.monthly_budget == pytest.approx(1_000_000)
+
+
+def test_load_slack_config_invalid_boolean_raises() -> None:
+    env = _base_env() | {"SLACK_INCLUDE_SPEND_RATE": "maybe"}
+
+    with pytest.raises(ConfigError):
+        load_slack_config(env)
+


### PR DESCRIPTION
## Summary
- 環境変数からGoogle Ads/Slack/スケジュール設定を読み込む`config`モジュールを追加
- 設定値の検証を行う単体テストとサンプル`.env`ファイルを用意

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dbc4e87544832ea4e29c55636f43c2