### PR TITLE
Add workflow helpers and month-to-date cost aggregation

### DIFF
--- a/docs/next_steps.md
+++ b/docs/next_steps.md
@@ -41,7 +41,8 @@ language: "ja"
 - [x] 取得データを基に当日24時の着地予測を算出するBudget Predictorのプロトタイプを作成し、単純比例ロジックのテストを整備する。
 - [x] 通知テンプレート（本文構成、メトリクス表示フォーマット）を定義し、Slack等へメッセージ送信するNotification Handlerを実装する。
 - [ ] スケジューラ（APSchedulerやCloud Scheduler等）を活用し、ユーザー指定時刻でのジョブ実行を実現する。
-- [ ] Combined forecast結果を通知フォーマットへ統合し、UI／メッセージ例を作成する。
+- [x] Combined forecast結果を通知フォーマットへ統合し、UI／メッセージ例を作成する。
+    - `workflow.py` にスナップショット作成とSlackペイロード送信ユーティリティを追加し、`build_slack_notification_payload` を利用した通知処理を一元化した。
 - [ ] プロジェクト全体の設定検証コマンド（`python -m google_ads_alert doctor`想定）を実装し、運用前セルフチェック手順を整備する。
 
 ## 5. 運用と監視

--- a/src/google_ads_alert/__init__.py
+++ b/src/google_ads_alert/__init__.py
@@ -28,16 +28,28 @@ from .google_ads_client import (
     GoogleAdsCostService,
     GoogleAdsCredentials,
     GoogleAdsSearchTransport,
+    MonthToDateCostSummary,
     QueryRange,
     build_cost_query,
     build_daily_query_range,
+    build_month_to_date_query_range,
 )
 from .schedule import (
     DailyScheduleConfig,
+    DailyScheduleWindow,
     find_next_run_datetime,
     generate_daily_schedule,
+    generate_upcoming_run_windows,
+    generate_upcoming_run_times,
 )
 from .notification import SlackNotificationOptions, build_slack_notification_payload
+from .workflow import (
+    ForecastSnapshot,
+    NotificationSender,
+    SlackPayload,
+    build_forecast_snapshot,
+    dispatch_slack_alert,
+)
 from .logging_utils import LoggingConfig, configure_logging, get_logger
 
 __all__ = [
@@ -64,14 +76,24 @@ __all__ = [
     "GoogleAdsCostService",
     "GoogleAdsCredentials",
     "GoogleAdsSearchTransport",
+    "MonthToDateCostSummary",
     "QueryRange",
     "build_cost_query",
     "build_daily_query_range",
+    "build_month_to_date_query_range",
     "DailyScheduleConfig",
+    "DailyScheduleWindow",
     "find_next_run_datetime",
     "generate_daily_schedule",
+    "generate_upcoming_run_windows",
+    "generate_upcoming_run_times",
     "SlackNotificationOptions",
     "build_slack_notification_payload",
+    "ForecastSnapshot",
+    "NotificationSender",
+    "SlackPayload",
+    "build_forecast_snapshot",
+    "dispatch_slack_alert",
     "LoggingConfig",
     "configure_logging",
     "get_logger",

--- a/src/google_ads_alert/schedule.py
+++ b/src/google_ads_alert/schedule.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, replace
 from datetime import date, datetime, timedelta
-from typing import Iterable, List, Sequence
 
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .forecast import _coerce_timezone
 
@@ -72,7 +72,7 @@ def _build_anchor_datetime(
 
 def generate_daily_schedule(
     target_date: date, config: DailyScheduleConfig | None = None
-) -> List[datetime]:
+) -> list[datetime]:
     """Return alert run times for ``target_date``.
 
     The generated schedule always includes the start and end anchors. When
@@ -103,7 +103,7 @@ def generate_daily_schedule(
         return [start_dt, end_dt]
 
     step = interval_seconds / (cfg.run_count - 1)
-    schedule: List[datetime] = []
+    schedule: list[datetime] = []
     for i in range(cfg.run_count):
         delta = timedelta(seconds=step * i)
         schedule.append(start_dt + delta)
@@ -111,6 +111,21 @@ def generate_daily_schedule(
     # ensure final anchor is exactly aligned even with floating point rounding
     schedule[-1] = end_dt
     return schedule
+
+
+def _zoneinfo_from_datetime(dt: datetime) -> ZoneInfo | None:
+    tzinfo = dt.tzinfo
+    if tzinfo is None:
+        return None
+    if isinstance(tzinfo, ZoneInfo):
+        return tzinfo
+    tz_name = tzinfo.tzname(dt)
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except ZoneInfoNotFoundError:
+            return None
+    return None
 
 
 def find_next_run_datetime(
@@ -136,20 +151,24 @@ def find_next_run_datetime(
     if not schedule:
         return None
 
-    tz = timezone
-    for candidate in schedule:
-        if candidate.tzinfo is not None:
-            tz = candidate.tzinfo
-            break
-    tz = _coerce_timezone(tz)
+    tz_candidate = timezone
+    if tz_candidate is None:
+        for candidate in schedule:
+            candidate_tz = _zoneinfo_from_datetime(candidate)
+            if candidate_tz is not None:
+                tz_candidate = candidate_tz
+                break
+    if tz_candidate is None:
+        tz_candidate = _zoneinfo_from_datetime(now)
+    tz = _coerce_timezone(tz_candidate)
 
     if now.tzinfo is None:
         localized_now = now.replace(tzinfo=tz)
     else:
         localized_now = now.astimezone(tz)
 
-    def _normalize(entries: Iterable[datetime]) -> List[datetime]:
-        normalized: List[datetime] = []
+    def _normalize(entries: Iterable[datetime]) -> list[datetime]:
+        normalized: list[datetime] = []
         for entry in entries:
             if entry.tzinfo is None:
                 normalized.append(entry.replace(tzinfo=tz))
@@ -165,5 +184,82 @@ def find_next_run_datetime(
 
     return None
 
+@dataclass(frozen=True)
+class DailyScheduleWindow:
+    """Upcoming executions for a given date."""
 
-__all__ = ["DailyScheduleConfig", "generate_daily_schedule", "find_next_run_datetime"]
+    date: date
+    run_times: tuple[datetime, ...]
+
+
+def _resolve_schedule_context(
+    now: datetime, config: DailyScheduleConfig | None
+) -> tuple[ZoneInfo, DailyScheduleConfig, datetime]:
+    cfg = config or DailyScheduleConfig()
+    tz_candidate: ZoneInfo | None = cfg.timezone
+    if tz_candidate is None:
+        tz_candidate = _zoneinfo_from_datetime(now)
+    tz = _coerce_timezone(tz_candidate)
+
+    effective_cfg = cfg if cfg.timezone is not None else replace(cfg, timezone=tz)
+
+    if now.tzinfo is None:
+        localized_now = now.replace(tzinfo=tz)
+    else:
+        localized_now = now.astimezone(tz)
+
+    return tz, effective_cfg, localized_now
+
+
+def generate_upcoming_run_windows(
+    now: datetime,
+    days: int,
+    config: DailyScheduleConfig | None = None,
+) -> list[DailyScheduleWindow]:
+    """Return the remaining executions for each of the next ``days`` days.
+
+    The first window omits past run times relative to ``now`` while subsequent
+    windows include the full schedule for their date.
+    """
+
+    if days <= 0:
+        raise ValueError("days must be greater than 0")
+
+    _tz, effective_cfg, localized_now = _resolve_schedule_context(now, config)
+
+    windows: list[DailyScheduleWindow] = []
+    current_date = localized_now.date()
+    for offset in range(days):
+        target_date = current_date + timedelta(days=offset)
+        daily_schedule = generate_daily_schedule(target_date, effective_cfg)
+        if offset == 0:
+            runs = tuple(run for run in daily_schedule if run >= localized_now)
+        else:
+            runs = tuple(daily_schedule)
+        windows.append(DailyScheduleWindow(date=target_date, run_times=runs))
+
+    return windows
+
+
+def generate_upcoming_run_times(
+    now: datetime,
+    days: int,
+    config: DailyScheduleConfig | None = None,
+) -> list[datetime]:
+    """Return scheduled executions from ``now`` across ``days`` days."""
+
+    windows = generate_upcoming_run_windows(now, days, config)
+    upcoming: list[datetime] = []
+    for window in windows:
+        upcoming.extend(window.run_times)
+    return upcoming
+
+
+__all__ = [
+    "DailyScheduleConfig",
+    "DailyScheduleWindow",
+    "generate_daily_schedule",
+    "find_next_run_datetime",
+    "generate_upcoming_run_windows",
+    "generate_upcoming_run_times",
+]

--- a/src/google_ads_alert/workflow.py
+++ b/src/google_ads_alert/workflow.py
@@ -1,0 +1,105 @@
+"""Workflow helpers for orchestrating Google Ads budget alerts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+from zoneinfo import ZoneInfo
+
+from .forecast import (
+    CombinedForecastInput,
+    CombinedForecastResult,
+    build_combined_forecast,
+    _coerce_timezone,
+)
+from .google_ads_client import (
+    DailyCostSummary,
+    GoogleAdsCostService,
+    MonthToDateCostSummary,
+)
+from .notification import SlackNotificationOptions, build_slack_notification_payload
+
+SlackPayload = dict[str, object]
+
+
+class NotificationSender(Protocol):
+    """Callable contract for dispatching rendered notification payloads."""
+
+    def __call__(self, payload: SlackPayload) -> None:  # pragma: no cover - interface
+        ...
+
+
+@dataclass(frozen=True)
+class ForecastSnapshot:
+    """Collected spend summaries and rendered forecast for an alert cycle."""
+
+    as_of: datetime
+    daily_cost: DailyCostSummary
+    month_to_date_cost: MonthToDateCostSummary
+    forecast: CombinedForecastResult
+
+
+def build_forecast_snapshot(
+    cost_service: GoogleAdsCostService,
+    *,
+    as_of: datetime | None = None,
+    daily_budget: float | None = None,
+    monthly_budget: float | None = None,
+    timezone_override: ZoneInfo | None = None,
+) -> ForecastSnapshot:
+    """Create a consolidated forecast snapshot using ``cost_service`` data."""
+
+    reference = as_of or datetime.now(timezone.utc)
+
+    daily_summary = cost_service.fetch_daily_cost(reference)
+    month_summary = cost_service.fetch_month_to_date_cost(reference)
+
+    tz_candidate = timezone_override
+    if tz_candidate is None:
+        summary_tz = daily_summary.as_of.tzinfo
+        if isinstance(summary_tz, ZoneInfo):
+            tz_candidate = summary_tz
+
+    tz = _coerce_timezone(tz_candidate)
+
+    forecast = build_combined_forecast(
+        CombinedForecastInput(
+            as_of=daily_summary.as_of,
+            current_spend=daily_summary.total_cost,
+            month_to_date_spend=month_summary.total_cost,
+            daily_budget=daily_budget,
+            monthly_budget=monthly_budget,
+            timezone=tz,
+        )
+    )
+
+    return ForecastSnapshot(
+        as_of=daily_summary.as_of,
+        daily_cost=daily_summary,
+        month_to_date_cost=month_summary,
+        forecast=forecast,
+    )
+
+
+def dispatch_slack_alert(
+    snapshot: ForecastSnapshot,
+    sender: NotificationSender,
+    *,
+    options: SlackNotificationOptions | None = None,
+) -> SlackPayload:
+    """Render a Slack payload for ``snapshot`` and hand it to ``sender``."""
+
+    payload = build_slack_notification_payload(snapshot.forecast, options)
+    sender(payload)
+    return payload
+
+
+__all__ = [
+    "ForecastSnapshot",
+    "NotificationSender",
+    "SlackPayload",
+    "build_forecast_snapshot",
+    "dispatch_slack_alert",
+]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from google_ads_alert.google_ads_client import DailyCostSummary, MonthToDateCostSummary
+from google_ads_alert.notification import SlackNotificationOptions
+from google_ads_alert.workflow import (
+    build_forecast_snapshot,
+    dispatch_slack_alert,
+)
+
+
+class DummyCostService:
+    def __init__(
+        self,
+        daily_summary: DailyCostSummary,
+        month_summary: MonthToDateCostSummary,
+    ) -> None:
+        self._daily = daily_summary
+        self._monthly = month_summary
+        self.daily_calls: list[datetime] = []
+        self.monthly_calls: list[datetime] = []
+
+    def fetch_daily_cost(self, as_of: datetime) -> DailyCostSummary:
+        self.daily_calls.append(as_of)
+        return self._daily
+
+    def fetch_month_to_date_cost(self, as_of: datetime) -> MonthToDateCostSummary:
+        self.monthly_calls.append(as_of)
+        return self._monthly
+
+
+@pytest.fixture
+def snapshot_inputs() -> tuple[DummyCostService, datetime]:
+    tz = ZoneInfo("Asia/Tokyo")
+    daily_summary = DailyCostSummary(
+        as_of=datetime(2024, 6, 10, 12, 0, tzinfo=tz),
+        report_start=datetime(2024, 6, 10, tzinfo=tz),
+        report_end=datetime(2024, 6, 11, tzinfo=tz),
+        total_cost_micros=5_000_000,
+    )
+    monthly_summary = MonthToDateCostSummary(
+        as_of=datetime(2024, 6, 10, 12, 0, tzinfo=tz),
+        report_start=datetime(2024, 6, 1, tzinfo=tz),
+        report_end=datetime(2024, 6, 11, tzinfo=tz),
+        total_cost_micros=55_000_000,
+    )
+    service = DummyCostService(daily_summary, monthly_summary)
+    reference = datetime(2024, 6, 10, 3, 0, tzinfo=ZoneInfo("UTC"))
+    return service, reference
+
+
+def test_build_forecast_snapshot_aggregates_costs(snapshot_inputs) -> None:
+    service, reference = snapshot_inputs
+    tz = ZoneInfo("Asia/Tokyo")
+
+    snapshot = build_forecast_snapshot(
+        service,
+        as_of=reference,
+        daily_budget=10.0,
+        monthly_budget=300.0,
+        timezone_override=tz,
+    )
+
+    assert service.daily_calls[0] == reference
+    assert service.monthly_calls[0] == reference
+    assert snapshot.as_of == service._daily.as_of
+    assert snapshot.daily_cost.total_cost == pytest.approx(5.0)
+    assert snapshot.month_to_date_cost.total_cost == pytest.approx(55.0)
+    assert snapshot.forecast.daily.projected_spend == pytest.approx(10.0)
+    assert snapshot.forecast.daily_budget == pytest.approx(10.0)
+    assert snapshot.forecast.monthly_budget == pytest.approx(300.0)
+    assert snapshot.forecast.monthly.month_to_date_spend == pytest.approx(55.0)
+
+
+def test_dispatch_slack_alert_sends_payload(snapshot_inputs) -> None:
+    service, reference = snapshot_inputs
+
+    snapshot = build_forecast_snapshot(service, as_of=reference)
+
+    sent_payloads: list[dict[str, object]] = []
+
+    payload = dispatch_slack_alert(
+        snapshot,
+        sent_payloads.append,
+        options=SlackNotificationOptions(account_name="Test"),
+    )
+
+    assert sent_payloads and sent_payloads[0] is payload
+    assert payload["blocks"][0]["type"] == "header"
+    assert "最終更新" in payload["blocks"][1]["elements"][0]["text"]


### PR DESCRIPTION
## Summary
- extend the Google Ads cost service with a month-to-date query helper and summary dataclass
- add a workflow module that composes forecast snapshots and Slack payload dispatching utilities
- cover the new helpers with unit tests and document the completed notification integration work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf3e5bdd8832e83abe295c7b8b9a4